### PR TITLE
Moved secondary_navlinks after search links.

### DIFF
--- a/style/template/navbar_header.html
+++ b/style/template/navbar_header.html
@@ -144,13 +144,13 @@
 		<!-- EVENT secondary_navlinks_after -->
 		{% endset %}
 		{% if secondary_links|trim %}
-			{{ secondary_links }}
 			<!-- IF $NAVLINKS_SHOW_DEFAULT && S_DISPLAY_SEARCH -->
 				<li class="small-icon icon-search{% if definition.SEARCH_IN_NAVBAR == 1 && definition.SEARCH_BOX %} responsive-hide{% endif %}"><a href="{U_SEARCH}">{L_SEARCH}</a></li>
 				<!-- IF S_USER_LOGGED_IN -->
 					<li class="small-icon icon-new-posts"><a href="{U_SEARCH_NEW}" role="menuitem">{L_SEARCH_NEW}</a></li>
 				<!-- ENDIF -->
 			<!-- ENDIF -->
+			{{ secondary_links }}
 		{% else %}
 			<!-- IF S_DISPLAY_SEARCH -->
 				<li class="small-icon icon-search{% if definition.SEARCH_IN_NAVBAR == 1 && definition.SEARCH_BOX %} responsive-hide{% endif %}"><a href="{U_SEARCH}">{L_SEARCH}</a></li>


### PR DESCRIPTION
As mark_all_as_read link appeared directly below a dropdown with show_all_unread user might accidentally mark_all_as_read while trying to see unread posts.
